### PR TITLE
Mrr/move raven monkey patches to gem

### DIFF
--- a/lib/raven/extra.rb
+++ b/lib/raven/extra.rb
@@ -26,10 +26,20 @@ end
 
 module Raven
   class << self
+    def tags_context_with_string_keys(options = nil)
+      tags_context_without_string_keys(options.try(:stringify_keys))
+    end
+
+    def extra_context_with_string_keys(options = nil)
+      extra_context_without_string_keys(options.try(:stringify_keys))
+    end
+
     def capture_message_with_level(message, options={})
       capture_message_without_level(message, options.reverse_merge(:level => :info))
     end
 
+    alias_method_chain :tags_context, :string_keys
+    alias_method_chain :extra_context, :string_keys
     alias_method_chain :capture_message, :level
   end
 

--- a/lib/raven/extra.rb
+++ b/lib/raven/extra.rb
@@ -25,6 +25,14 @@ class Object
 end
 
 module Raven
+  class << self
+    def capture_message_with_level(message, options={})
+      capture_message_without_level(message, options.reverse_merge(:level => :info))
+    end
+
+    alias_method_chain :capture_message, :level
+  end
+
   class Event
     def parse_exception_with_extra(exception)
       parse_exception_without_extra(exception)


### PR DESCRIPTION
I considered moving these into raven-ruby, but there are so many places where things would need to be stringified that it's a considerable project.

This protects our use case in the interim of tackling that project.